### PR TITLE
Base Quest Stuff

### DIFF
--- a/adventure-crew-game/Assets/ScriptableObjects.meta
+++ b/adventure-crew-game/Assets/ScriptableObjects.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d48964ea1a18bdf4baae5a54c84c7fa6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/adventure-crew-game/Assets/ScriptableObjects/Quest.meta
+++ b/adventure-crew-game/Assets/ScriptableObjects/Quest.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0981c6bbe955e2b4aaa6980401ca4ffb
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/adventure-crew-game/Assets/ScriptableObjects/Quest/New Quest.asset
+++ b/adventure-crew-game/Assets/ScriptableObjects/Quest/New Quest.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a3ad044bf2831fd4eb89bb40d1e7ebd6, type: 3}
+  m_Name: New Quest
+  m_EditorClassIdentifier: 
+  description: This is a test quest
+  questTitle: Test Quest
+  encounters:
+  - {fileID: 11400000, guid: 3726628b85d82614a940cf30ca24b9b3, type: 2}
+  - {fileID: 11400000, guid: ddb8f693f97aa99448e73a4440aca0e8, type: 2}

--- a/adventure-crew-game/Assets/ScriptableObjects/Quest/New Quest.asset.meta
+++ b/adventure-crew-game/Assets/ScriptableObjects/Quest/New Quest.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 58cc8bbf7b66360449dfab936c8b56f5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/adventure-crew-game/Assets/ScriptableObjects/Quest/TestCombat.asset
+++ b/adventure-crew-game/Assets/ScriptableObjects/Quest/TestCombat.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3b123414d5cc47745b238388de50d7cb, type: 3}
+  m_Name: TestCombat
+  m_EditorClassIdentifier: 

--- a/adventure-crew-game/Assets/ScriptableObjects/Quest/TestCombat.asset.meta
+++ b/adventure-crew-game/Assets/ScriptableObjects/Quest/TestCombat.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3726628b85d82614a940cf30ca24b9b3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/adventure-crew-game/Assets/ScriptableObjects/Quest/TestDecision.asset
+++ b/adventure-crew-game/Assets/ScriptableObjects/Quest/TestDecision.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b12f0554138cff948b5f02ac9644cbdb, type: 3}
+  m_Name: TestDecision
+  m_EditorClassIdentifier: 
+  encounterText: 
+  decision1Text: 
+  decision2Text: 
+  decisionUI: {fileID: 0}

--- a/adventure-crew-game/Assets/ScriptableObjects/Quest/TestDecision.asset.meta
+++ b/adventure-crew-game/Assets/ScriptableObjects/Quest/TestDecision.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ddb8f693f97aa99448e73a4440aca0e8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/adventure-crew-game/Assets/Scripts/QuestSystem.meta
+++ b/adventure-crew-game/Assets/Scripts/QuestSystem.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3a0e7ac4dff390c418a666c3ea88f6b8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/adventure-crew-game/Assets/Scripts/QuestSystem/CombatEncounter.cs
+++ b/adventure-crew-game/Assets/Scripts/QuestSystem/CombatEncounter.cs
@@ -1,0 +1,18 @@
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "SOs/CombatEncounter")]
+public class CombatEncounter : Encounter
+{
+    //To do: Add enemy entities for combat
+
+    public override void OnEnd()
+    {
+
+    }
+
+
+    public override void OnStart()
+    {
+
+    }
+}

--- a/adventure-crew-game/Assets/Scripts/QuestSystem/CombatEncounter.cs.meta
+++ b/adventure-crew-game/Assets/Scripts/QuestSystem/CombatEncounter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3b123414d5cc47745b238388de50d7cb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/adventure-crew-game/Assets/Scripts/QuestSystem/DecisionEncounter.cs
+++ b/adventure-crew-game/Assets/Scripts/QuestSystem/DecisionEncounter.cs
@@ -1,0 +1,35 @@
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "SOs/DecisionEncounter")]
+public class DecisionEncounter : Encounter
+{
+    [TextArea]
+    public string encounterText;
+    public string decision1Text;
+    public string decision2Text;
+    public GameObject decisionUI;
+    
+    public override void OnStart()
+    {
+
+    }
+
+    public override void OnEnd()
+    {
+
+    }
+
+    public void Decision1()
+    {
+        // Do something
+        
+        OnEnd();
+    }
+
+    public void Decision2()
+    {
+        // Do something
+
+        OnEnd();
+    }
+}

--- a/adventure-crew-game/Assets/Scripts/QuestSystem/DecisionEncounter.cs.meta
+++ b/adventure-crew-game/Assets/Scripts/QuestSystem/DecisionEncounter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b12f0554138cff948b5f02ac9644cbdb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/adventure-crew-game/Assets/Scripts/QuestSystem/Encounter.cs
+++ b/adventure-crew-game/Assets/Scripts/QuestSystem/Encounter.cs
@@ -1,0 +1,9 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public abstract class Encounter : ScriptableObject
+{
+    public abstract void OnStart();
+    public abstract void OnEnd();
+}

--- a/adventure-crew-game/Assets/Scripts/QuestSystem/Encounter.cs.meta
+++ b/adventure-crew-game/Assets/Scripts/QuestSystem/Encounter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c9f2b756e404e3643a7d3c3eb92ce7f7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/adventure-crew-game/Assets/Scripts/QuestSystem/Quest.cs
+++ b/adventure-crew-game/Assets/Scripts/QuestSystem/Quest.cs
@@ -1,0 +1,14 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "SOs/Quest")]
+public class Quest : ScriptableObject
+{
+    [TextArea]
+    public string description;
+    public string questTitle;
+
+    public List<Encounter> encounters;
+    private Encounter activeEncounter;
+}

--- a/adventure-crew-game/Assets/Scripts/QuestSystem/Quest.cs.meta
+++ b/adventure-crew-game/Assets/Scripts/QuestSystem/Quest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a3ad044bf2831fd4eb89bb40d1e7ebd6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
<!---
Pull request template for 603 Game 3. Feel free to remove comments as you fill out information.
Original template by Rob Reddick
--->
## Summarize what is being added
Adding the class system that will allow us to set up questlines. Currently implementing quests as lists of encounters, will set making trees a stretch goal.

## Please describe how to test
Open the project, right click to open the Create menu. Create some encounter objects, create a quest object and add the encounters to it.

## Relevant Screenshots
<!---Paste in some screenshots to help reduce need of excess testing. If screenshots are not relevant here, then remove this section--->
![image](https://github.com/amonjerro/adventure-crew/assets/9394777/b5fb82e6-e01b-4e15-aa68-f5b80b556651)


## Issue worked on
#13 

## What Week of the 603 cycle is this due in?
Friday alpha
