### PR TITLE
Exhaustion System

### DIFF
--- a/adventure-crew-game/Assets/Scenes/MapScene.unity
+++ b/adventure-crew-game/Assets/Scenes/MapScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.18028378, g: 0.22571412, b: 0.30692285, a: 1}
+  m_IndirectSpecularColor: {r: 0.18028334, g: 0.22571328, b: 0.3069217, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -4386,6 +4386,18 @@ MonoBehaviour:
         m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
         m_MethodName: SetActive
         m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 1751508176}
+        m_TargetAssemblyTypeName: AdventurerDisplay, Assembly-CSharp
+        m_MethodName: UpdateDisplay
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine

--- a/adventure-crew-game/Assets/Scripts/Characters/Adventurer.cs
+++ b/adventure-crew-game/Assets/Scripts/Characters/Adventurer.cs
@@ -2,9 +2,10 @@ public class Adventurer : ICharacter
 {
     Stats combatStats;
     ICombatStrategy aiStrategy;
-    public int Exhaustion { get; set; }
+    public float Exhaustion { get; set; }
     public int XP { get; set; }
     public int Level { get; private set; }
+    public bool OnQuest { get; set; }
 
     public enum Rank
     {
@@ -50,6 +51,26 @@ public class Adventurer : ICharacter
             Level = newLevel;
 
             // Other bells and whistles, increase stats, etc.
+        }
+    }
+
+    /// <summary>
+    /// If the Adventurers were just on a quest, they get more exhausted based on how much HP they have left.
+    /// If they were not on a quest, they regain exhaustion as a substitute for our wait time for the playtest.
+    /// </summary>
+    public void AdjustExhaustion()
+    {
+        if (OnQuest)
+        {
+            Exhaustion += 50f /** (((float)combatStats.MaxHP - (float)combatStats.HP) / (float)combatStats.MaxHP)*/;
+            OnQuest = false;
+        }
+        else
+        {
+            Exhaustion -= 20;
+           
+            if (Exhaustion < 0)
+                Exhaustion = 0;
         }
     }
 }

--- a/adventure-crew-game/Assets/Scripts/Characters/AdventurerList.cs
+++ b/adventure-crew-game/Assets/Scripts/Characters/AdventurerList.cs
@@ -63,4 +63,13 @@ public static class AdventurerList
         QuickSort(ref list, low, i - 1);
         QuickSort(ref list, i + 1, high);
     }
+
+    public static void ExhaustAdventurers()
+    {
+        for(int i = 0; i < Adventurers.Count; i++)
+        {
+            Adventurers[i].AdjustExhaustion();
+            Debug.Log("This dudes exhausted " + Adventurers[i].Exhaustion + " much");
+        }
+    }
 }

--- a/adventure-crew-game/Assets/Scripts/Combat/CombatStageController.cs
+++ b/adventure-crew-game/Assets/Scripts/Combat/CombatStageController.cs
@@ -42,6 +42,7 @@ public class CombatStageController : MonoBehaviour
     }
     private void GoBackToMap()
     {
+        AdventurerList.ExhaustAdventurers();
         SceneManager.LoadScene(1);
     }
 }

--- a/adventure-crew-game/Assets/Scripts/Combat/FormationController.cs
+++ b/adventure-crew-game/Assets/Scripts/Combat/FormationController.cs
@@ -32,6 +32,7 @@ public class FormationController : MonoBehaviour
     {
         GameObject go = Instantiate(adventurer);
         go.GetComponent<CombatEntityAdventurer>().InititCombatAdventurer(AdventurerList.Adventurers[id].GetStats());
+        AdventurerList.Adventurers[id].OnQuest = true;
         go.AddComponent<FollowMouse>().FollowMouseInit(this);
     }
     public void ResetButton()

--- a/adventure-crew-game/Assets/Scripts/UI/AdventurerDisplay.cs
+++ b/adventure-crew-game/Assets/Scripts/UI/AdventurerDisplay.cs
@@ -42,7 +42,7 @@ public class AdventurerDisplay : MonoBehaviour
         AdventurerList.RemoveAnAdventurer(index);
         UpdateDisplay();
     }
-    private void UpdateDisplay()
+    public void UpdateDisplay()
     {
         AdventurerUIElement[] allChildren = content.GetComponentsInChildren<AdventurerUIElement>();
         foreach (AdventurerUIElement child in allChildren)

--- a/adventure-crew-game/Assets/Scripts/UI/AdventurerUIElement.cs
+++ b/adventure-crew-game/Assets/Scripts/UI/AdventurerUIElement.cs
@@ -16,4 +16,9 @@ public class AdventurerUIElement : MonoBehaviour
         rankText.text = AdventurerList.Adventurers[ID].rank.ToString();
         exhaustionText.text = AdventurerList.Adventurers[ID].Exhaustion.ToString();
     }
+
+    public void UpdateExhaustion()
+    {
+        exhaustionText.text = AdventurerList.Adventurers[ID].Exhaustion.ToString();
+    }
 }

--- a/adventure-crew-game/ProjectSettings/EditorBuildSettings.asset
+++ b/adventure-crew-game/ProjectSettings/EditorBuildSettings.asset
@@ -14,4 +14,10 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/Tsingtao/Battlefield-Non-Test.unity
     guid: 0b68a522b74fa5c4ab7a2774e0e6eed0
+  - enabled: 0
+    path: Assets/Scenes/MapTestScene.unity
+    guid: c3b28d35f5a69c44f91509500a8fde59
+  - enabled: 0
+    path: Assets/Scenes/Tsingtao/BattleField Dynamic Formations.unity
+    guid: 35acf88990cd040499522374ea15769a
   m_configObjects: {}


### PR DESCRIPTION
When adventurers participate in a quest, they gain exhaustion, and when they don't, they lose exhaustion.

<!---
Pull request template for 603 Game 3. Feel free to remove comments as you fill out information.
Original template by Rob Reddick
--->
## Summarize what is being added
Exhaustion values are now tracked after combat (currently adds a static value but math will be implemented soon) and logged in the Adventurer UI
## Please describe how to test
Play the game, enter combat and drag any number of adventurers into the scene. Return to the map and click the adventurer window to see the exhaustion values of every adventurer that participated in combat changed.

## Relevant Screenshots
![603CombatEx](https://github.com/amonjerro/adventure-crew/assets/70346282/4b762c80-2374-4dee-9ded-5854647f30fd)
![603CombatExUI](https://github.com/amonjerro/adventure-crew/assets/70346282/db1a6954-41da-4fca-bf6d-078f032daa65)

## Issue worked on
https://github.com/amonjerro/adventure-crew/issues/49

## What Week of the 603 cycle is this due in?
Week 2 Beta


