### PR TITLE
quick fix

### DIFF
--- a/adventure-crew-game/Assets/Scenes/Tsingtao/Battlefield-Non-Test.unity
+++ b/adventure-crew-game/Assets/Scenes/Tsingtao/Battlefield-Non-Test.unity
@@ -2578,7 +2578,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!114 &2094682311
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/adventure-crew-game/Assets/Scripts/Combat/CombatStageController.cs
+++ b/adventure-crew-game/Assets/Scripts/Combat/CombatStageController.cs
@@ -17,12 +17,17 @@ public class CombatStageController : MonoBehaviour
         startCombatButton.onClick.AddListener(StartCombat);
         backToMapButton.onClick.AddListener(GoBackToMap);
         CombatManager.Instance.combatEnded += EndCombat;
+
+        startCombatButton.interactable = false;
+        FollowMouse.ReadyToFight += () => startCombatButton.interactable = true;
     }
     private void OnDisable()
     {
         startCombatButton.onClick.RemoveAllListeners();
         backToMapButton.onClick.RemoveAllListeners();
         CombatManager.Instance.combatEnded -= EndCombat;
+
+        FollowMouse.ReadyToFight -= () => startCombatButton.interactable = true;
     }
     private void Start()
     {

--- a/adventure-crew-game/Assets/Scripts/Combat/FollowMouse.cs
+++ b/adventure-crew-game/Assets/Scripts/Combat/FollowMouse.cs
@@ -23,6 +23,7 @@ public class FollowMouse : MonoBehaviour
     {
         if(Input.GetMouseButtonDown(0))
         {
+            AdventurerList.Adventurers[controller.ID].OnQuest = true;
             Destroy(this);
         }
         if(Input.GetMouseButtonDown(1))

--- a/adventure-crew-game/Assets/Scripts/Combat/FollowMouse.cs
+++ b/adventure-crew-game/Assets/Scripts/Combat/FollowMouse.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -19,11 +20,15 @@ public class FollowMouse : MonoBehaviour
             transform.position = hit.point;
         }
     }
+    public static Action ReadyToFight;
+    //This action is subscribed by: CombatStageController
+
     private void Update()
     {
         if(Input.GetMouseButtonDown(0))
         {
             AdventurerList.Adventurers[controller.ID].OnQuest = true;
+            if(ReadyToFight != null) ReadyToFight();
             Destroy(this);
         }
         if(Input.GetMouseButtonDown(1))

--- a/adventure-crew-game/Assets/Scripts/Combat/FormationController.cs
+++ b/adventure-crew-game/Assets/Scripts/Combat/FormationController.cs
@@ -32,7 +32,6 @@ public class FormationController : MonoBehaviour
     {
         GameObject go = Instantiate(adventurer);
         go.GetComponent<CombatEntityAdventurer>().InititCombatAdventurer(AdventurerList.Adventurers[id].GetStats());
-        AdventurerList.Adventurers[id].OnQuest = true;
         go.AddComponent<FollowMouse>().FollowMouseInit(this);
     }
     public void ResetButton()


### PR DESCRIPTION
<!---
Pull request template for 603 Game 3. Feel free to remove comments as you fill out information.
Original template by Rob Reddick
--->
## Summarize what is being added
<!--- Can use bullet lists here to cover new additions, but give a bit more detail than what is given in commit messages --->
A follow up hot fix after Exahustion 
I missed that the selected adventurer can be canceled (by right click) and eventually not be placed into the battlefield.
So I just changed two scripts, and basically I just moved the exahustion function to FollowMouse script, that's where it finally decides if in battle.
## Please describe how to test
<!---Give the important steps needed for testing your main changes--->
Go to Assets\Scenes\Tsingtao\Battlefield-Non-Test, left click on the first one from the left, but then right click to cancel. Then put any other adventurers to finish the battle. When returned to the map, check that the first one isn't increased by exahustion.
## Relevant Screenshots
<!---Paste in some screenshots to help reduce need of excess testing. If screenshots are not relevant here, then remove this section--->

## Issue worked on
<!---Paste in a link to the issue this PR addresses--->

## What Week of the 603 cycle is this due in?
<!---Only need to indicate here which week/deliverable the PR is for--->
