### PR TITLE
Exhaustion Updates

### DIFF
--- a/adventure-crew-game/Assets/Materials/PowerCylinder.mat
+++ b/adventure-crew-game/Assets/Materials/PowerCylinder.mat
@@ -116,7 +116,7 @@ Material:
     - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
     - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
-    - _PowerColor: {r: 0.8207547, g: 0.43205178, b: 0.042586334, a: 0}
+    - _PowerColor: {r: 0.054734774, g: 0.29343432, b: 0.7735849, a: 0}
     - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
   m_BuildTextureStacks: []
 --- !u!114 &6242302660007803990

--- a/adventure-crew-game/Assets/Scenes/MapScene.unity
+++ b/adventure-crew-game/Assets/Scenes/MapScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.18028378, g: 0.22571412, b: 0.30692285, a: 1}
+  m_IndirectSpecularColor: {r: 0.18028334, g: 0.22571328, b: 0.3069217, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -233,6 +233,7 @@ RectTransform:
   - {fileID: 2083175072}
   - {fileID: 1307276723}
   - {fileID: 745671808}
+  - {fileID: 753830251}
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1784,6 +1785,57 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 747809104}
   m_CullTransparentMesh: 1
+--- !u!1 &753830250
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 753830251}
+  - component: {fileID: 753830252}
+  m_Layer: 5
+  m_Name: ExhaustionManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &753830251
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 753830250}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1688239119}
+  m_Father: {fileID: 8671286}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &753830252
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 753830250}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1d252e37d8d17ed45a20e84d40d62f6b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  timerText: {fileID: 1688239120}
 --- !u!224 &763511598 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 5732151340177753925, guid: a6992616d2614d440ac4aa93cb899681,
@@ -5193,6 +5245,142 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1659832057}
+  m_CullTransparentMesh: 1
+--- !u!1 &1688239118
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1688239119}
+  - component: {fileID: 1688239121}
+  - component: {fileID: 1688239120}
+  m_Layer: 5
+  m_Name: TimerText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1688239119
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1688239118}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 753830251}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 519, y: 379}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1688239120
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1688239118}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 0:00
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 16198aaffb29ba54b8158e9927a1520b, type: 2}
+  m_sharedMaterial: {fileID: 877897986941153224, guid: 16198aaffb29ba54b8158e9927a1520b,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1688239121
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1688239118}
   m_CullTransparentMesh: 1
 --- !u!1 &1751508174 stripped
 GameObject:

--- a/adventure-crew-game/Assets/Scripts/Characters/Adventurer.cs
+++ b/adventure-crew-game/Assets/Scripts/Characters/Adventurer.cs
@@ -6,6 +6,7 @@ public class Adventurer : ICharacter
     public int XP { get; set; }
     public int Level { get; private set; }
     public bool OnQuest { get; set; }
+    public float HealInterval { get; private set; }
 
     public enum Rank
     {
@@ -32,7 +33,8 @@ public class Adventurer : ICharacter
 
     public void Die()
     {
-
+        AdventurerList.Adventurers.Remove(this);
+        AdventurerList.QuickSort(ref AdventurerList.Adventurers, 0, AdventurerList.Adventurers.Count - 1);
     }
 
     public void SetStrategy(ICombatStrategy strat)
@@ -66,15 +68,20 @@ public class Adventurer : ICharacter
     {
         if (OnQuest)
         {
-            Exhaustion += 50f /** (((float)combatStats.MaxHP - (float)combatStats.HP) / (float)combatStats.MaxHP)*/;
+            Exhaustion += (int)(50f * ((combatStats.MaxHP + 1 - combatStats.HP) / combatStats.MaxHP));
             OnQuest = false;
+            HealInterval = (combatStats.MaxHP - combatStats.HP + 1) / Exhaustion;
+            if(Exhaustion >= 100)
+            {
+                Die();
+            }
         }
-        else
-        {
-            Exhaustion -= 20;
+        //else
+        //{
+        //    Exhaustion -= 20;
            
-            if (Exhaustion < 0)
-                Exhaustion = 0;
-        }
+        //    if (Exhaustion < 0)
+        //        Exhaustion = 0;
+        //}
     }
 }

--- a/adventure-crew-game/Assets/Scripts/Characters/AdventurerList.cs
+++ b/adventure-crew-game/Assets/Scripts/Characters/AdventurerList.cs
@@ -69,7 +69,6 @@ public static class AdventurerList
         for(int i = 0; i < Adventurers.Count; i++)
         {
             Adventurers[i].AdjustExhaustion();
-            Debug.Log("This dudes exhausted " + Adventurers[i].Exhaustion + " much");
         }
     }
 }

--- a/adventure-crew-game/Assets/Scripts/Characters/ExhaustionCooldown.cs
+++ b/adventure-crew-game/Assets/Scripts/Characters/ExhaustionCooldown.cs
@@ -1,0 +1,88 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+
+public class ExhaustionCooldown : MonoBehaviour
+{
+    private float timeLeft;
+    private float currentTimeInterval;
+
+    [SerializeField]
+    private TextMeshProUGUI timerText;
+
+    private float mostExhaustion;
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        mostExhaustion = 0f;
+        foreach(Adventurer adv in AdventurerList.Adventurers)
+        {
+            if (adv.Exhaustion > mostExhaustion)
+                mostExhaustion = adv.Exhaustion;
+        }
+
+        timeLeft = mostExhaustion;
+        currentTimeInterval = timeLeft;
+        if(mostExhaustion == 0)
+        {
+            timerText.gameObject.SetActive(false);
+        }
+        else
+        {
+            timerText.gameObject.SetActive(true);
+        }
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        if(timeLeft > 0)
+        {
+            timeLeft -= Time.deltaTime;
+            UpdateExhaustion(timeLeft);
+        }
+        else
+        {
+            timeLeft = 0;
+        }
+    }
+
+    private void UpdateExhaustion(float currentTime)
+    {
+        if(currentTime <= currentTimeInterval - 1)
+        {
+            for(int i = 0; i < AdventurerList.Adventurers.Count; i++)
+            {
+                if (AdventurerList.Adventurers[i].Exhaustion > 0)
+                {
+                    Adventurer curAdv = AdventurerList.Adventurers[i];
+                    curAdv.Exhaustion -= 1;
+                    if (curAdv.GetStats().HP < curAdv.GetStats().MaxHP)
+                    {
+                        Stats healing = new Stats(curAdv.GetStats().HP + curAdv.HealInterval, curAdv.GetStats().MaxHP,
+                            curAdv.GetStats().Damage, curAdv.GetStats().Agility, curAdv.GetStats().Range);
+                        AdventurerList.Adventurers[i].SetStats(healing);
+                    }
+                    if (curAdv.GetStats().HP > curAdv.GetStats().MaxHP)
+                    {
+                        Stats healing = new Stats(curAdv.GetStats().MaxHP, curAdv.GetStats().MaxHP,
+                            curAdv.GetStats().Damage, curAdv.GetStats().Agility, curAdv.GetStats().Range);
+                        AdventurerList.Adventurers[i].SetStats(healing);
+                    }
+                }
+            }
+            currentTimeInterval -= 1;
+        }
+
+        //Found this method in a video: https://www.youtube.com/watch?v=hxpUk0qiRGs
+        currentTime += 1;
+
+        float minutes = Mathf.FloorToInt(currentTime / 60);
+        float seconds = Mathf.FloorToInt(currentTime % 60);
+
+        timerText.text = string.Format("{0:00} : {1:00}", minutes, seconds);
+    }
+}

--- a/adventure-crew-game/Assets/Scripts/Characters/ExhaustionCooldown.cs.meta
+++ b/adventure-crew-game/Assets/Scripts/Characters/ExhaustionCooldown.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1d252e37d8d17ed45a20e84d40d62f6b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/adventure-crew-game/Assets/Scripts/Characters/Stats.cs
+++ b/adventure-crew-game/Assets/Scripts/Characters/Stats.cs
@@ -5,14 +5,14 @@ using UnityEngine;
 public struct Stats
 {
 
-    public int HP;
-    public int MaxHP;
+    public float HP;
+    public float MaxHP;
     public int Damage;
     public int Agility;
     public float Range;
 
     // General Constructor
-    public Stats(int hp, int maxHP, int damage, int agility)
+    public Stats(float hp, float maxHP, int damage, int agility)
     {
         HP = hp;
         MaxHP = maxHP;
@@ -22,7 +22,7 @@ public struct Stats
     }
 
     // Constructor for ranged units
-    public Stats(int hp, int maxHP, int damage, int agility, float rng)
+    public Stats(float hp, float maxHP, int damage, int agility, float rng)
     {
         HP = hp;
         MaxHP = maxHP;


### PR DESCRIPTION
Exhaustion now scales depending on how much health each adventurer has after combat, the adventurers' health restores over time in the map scene after combat, a timer appears telling how much time until all adventurers are no longer exhausted, and Adventurers are removed from the list if they exceed 100 exhaustion

<!---
Pull request template for 603 Game 3. Feel free to remove comments as you fill out information.
Original template by Rob Reddick
--->
## Summarize what is being added
Exhaustion now scales depending on how much health each adventurer has after combat, the adventurers' health restores over time in the map scene after combat, a timer appears telling how much time until all adventurers are no longer exhausted, and Adventurers are removed from the list if they exceed 100 exhaustion

## Please describe how to test
Start the game, accept a quest and select any combination of adventurers for combat. After combat ends, go back to map and view the timer that appears above the adventurers button and the changes in health and exhaustion in the adventurers UI.

## Relevant Screenshots
![603ExTimer](https://github.com/amonjerro/adventure-crew/assets/70346282/caabb764-2321-452e-bbda-32e08b6ad18e)
![603ExAdventureUI](https://github.com/amonjerro/adventure-crew/assets/70346282/15440998-bbd5-4ea1-b136-9bb251d45261)
![603ExHealth](https://github.com/amonjerro/adventure-crew/assets/70346282/2d4d1aca-ce58-455f-9a43-479e194ed977)



## Issue worked on
https://github.com/amonjerro/adventure-crew/issues/49

## What Week of the 603 cycle is this due in?
Week 3 Playtest
