### PR TITLE
clear dead adventurers

### DIFF
--- a/adventure-crew-game/Assets/Scripts/Characters/AdventurerList.cs
+++ b/adventure-crew-game/Assets/Scripts/Characters/AdventurerList.cs
@@ -72,4 +72,21 @@ public static class AdventurerList
             Debug.Log("This dudes exhausted " + Adventurers[i].Exhaustion + " much");
         }
     }
+
+    public static void ClearDeads()
+    {
+        List<Adventurer> list = new List<Adventurer>();
+        foreach(Adventurer ad in Adventurers)
+        {
+            if(ad.GetStats().HP <= 0 || ad.Exhaustion >= 50)
+            {
+                list.Add(ad);
+            }
+        }
+
+        foreach(Adventurer ad in list)
+        {
+            Adventurers.Remove(ad);
+        }
+    }
 }

--- a/adventure-crew-game/Assets/Scripts/UI/AdventurerDisplay.cs
+++ b/adventure-crew-game/Assets/Scripts/UI/AdventurerDisplay.cs
@@ -44,6 +44,7 @@ public class AdventurerDisplay : MonoBehaviour
     }
     public void UpdateDisplay()
     {
+        AdventurerList.ClearDeads();
         AdventurerUIElement[] allChildren = content.GetComponentsInChildren<AdventurerUIElement>();
         foreach (AdventurerUIElement child in allChildren)
         {


### PR DESCRIPTION
<!---
Pull request template for 603 Game 3. Feel free to remove comments as you fill out information.
Original template by Rob Reddick
--->
## Summarize what is being added
<!--- Can use bullet lists here to cover new additions, but give a bit more detail than what is given in commit messages --->
add a function to remove the dead & exahusion >= 50.
## Please describe how to test
<!---Give the important steps needed for testing your main changes--->
Go from intro scene, have a battle, die some adventurers, and back to map, see the adventurer list, there should be only ones alive
## Relevant Screenshots
<!---Paste in some screenshots to help reduce need of excess testing. If screenshots are not relevant here, then remove this section--->

## Issue worked on
<!---Paste in a link to the issue this PR addresses--->

## What Week of the 603 cycle is this due in?
<!---Only need to indicate here which week/deliverable the PR is for--->
