### PR TITLE
Fixed post questing

### DIFF
--- a/adventure-crew-game/Assets/Scripts/UI/QuestUIManager.cs
+++ b/adventure-crew-game/Assets/Scripts/UI/QuestUIManager.cs
@@ -17,6 +17,7 @@ public class QuestUIManager : UIMenu
         panel.SetActive(true);
         title.text = q.questTitle;
         description.text = q.description;
+        firstButton.SetActive(true);
         firstButton.GetComponentInChildren<TextMeshProUGUI>().text = "Accept Quest";
         firstButton.GetComponent<QuestUIAction>().SetAction(ActionTypes.Accept);
         secondButtonText.text = "Reject";
@@ -70,6 +71,7 @@ public class QuestUIManager : UIMenu
         panel.SetActive(true);
         title.text = "";
         description.text = "Are you sure you want to move? You'll leave this quest unfinished and will have to start again.";
+        firstButton.SetActive(true);
         firstButton.GetComponentInChildren<TextMeshProUGUI>().text = "Disengage";
         firstButton.GetComponent<QuestUIAction>().SetAction(ActionTypes.Disengage);
         secondButtonText.text = "Reconsider";


### PR DESCRIPTION
<!---
Pull request template for 603 Game 3. Feel free to remove comments as you fill out information.
Original template by Rob Reddick
--->
## Summarize what is being added
On playtest, the game's UI would bug out and fail to display the Accept Quest button after finishing a quest.
This happened every single time players completed quests.

## Please describe how to test
Play the game, go to the Humble Beginning's quest. Play it completion. Try joining another quest - you should now be able to enter a new quest after finishing the first one.

## Relevant Screenshots
How it used to be
![image](https://github.com/amonjerro/adventure-crew/assets/9394777/180dbf42-d500-490b-9126-bcd39b3f0c0f)

How it should be
![image](https://github.com/amonjerro/adventure-crew/assets/9394777/ca72020c-5afe-4d4f-81ad-53082647eacc)


## Issue worked on
#63 

## What Week of the 603 cycle is this due in?
Friday release
