### PR TITLE
Reset functions implemented

### DIFF
--- a/adventure-crew-game/Assets/Scripts/Backend/CurrencySystem.cs
+++ b/adventure-crew-game/Assets/Scripts/Backend/CurrencySystem.cs
@@ -34,5 +34,10 @@ namespace Backend
             PlayerPrefs.SetInt("Coins", Coins);
             return true;
         }
+
+        public void Reset()
+        {
+            PlayerPrefs.SetInt("Coins", StartingCoins);
+        }
     }
 }

--- a/adventure-crew-game/Assets/Scripts/Characters/AdventurerList.cs
+++ b/adventure-crew-game/Assets/Scripts/Characters/AdventurerList.cs
@@ -88,4 +88,9 @@ public static class AdventurerList
             Adventurers.Remove(ad);
         }
     }
+
+    public static void Reset()
+    {
+        Adventurers.Clear();
+    }
 }

--- a/adventure-crew-game/Assets/Scripts/Combat/CombatData.cs
+++ b/adventure-crew-game/Assets/Scripts/Combat/CombatData.cs
@@ -1,3 +1,4 @@
+using JetBrains.Annotations;
 using UnityEngine;
 
 public static class CombatData
@@ -13,4 +14,13 @@ public static class CombatData
         activeEnemyFormation = formation;
     }
 
+    public static void Reset()
+    {
+        isQuestEngaged = false;
+        questEncounterIndex = 0;
+        lastMapLocation = Vector3.zero;
+        activeQuest = null;
+        lastCombatWon = false;
+        activeEnemyFormation = null;
+    }
 }

--- a/adventure-crew-game/Assets/Scripts/UI/PauseScreenBehavior.cs
+++ b/adventure-crew-game/Assets/Scripts/UI/PauseScreenBehavior.cs
@@ -1,3 +1,4 @@
+using Backend;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -41,6 +42,9 @@ public class PauseScreenBehavior : UIMenu
     public void BackToMainMenu()
     {
         //To do: Reset whatever is in DontDestroyOnLoad objects
+        CombatData.Reset();
+        AdventurerList.Reset();
+        CurrencySystem.Instance.Reset();
 
         Time.timeScale = 1.0f;
         SceneManager.LoadScene(0);


### PR DESCRIPTION
<!---
Pull request template for 603 Game 3. Feel free to remove comments as you fill out information.
Original template by Rob Reddick
--->
## Summarize what is being added
Added functionality to the pause screen behavior to reset our static classes and make sure that the action of returning to menu effectively clears data.

## Please describe how to test
Play the game for a bit, go back to main menu through the options menu, start the game again.

No data should've persisted - quests should be cleared, adventurers should retain information, nothing.

## Relevant Screenshots
<!---Paste in some screenshots to help reduce need of excess testing. If screenshots are not relevant here, then remove this section--->

## Issue worked on
#68 

## What Week of the 603 cycle is this due in?
Friday Release