### PR TITLE
power with bullet time, place power with mouse pos, and continue to t…

### DIFF
--- a/adventure-crew-game/Assets/Prefabs/Combat/PowerEffect.prefab
+++ b/adventure-crew-game/Assets/Prefabs/Combat/PowerEffect.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 7981442792223973070}
   - component: {fileID: 4949990842410413891}
   - component: {fileID: 4976997035663801221}
+  - component: {fileID: 5120778147521000280}
   m_Layer: 0
   m_Name: PowerEffect
   m_TagString: Untagged
@@ -31,7 +32,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 9
+  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &4949990842410413891
 MeshFilter:
@@ -83,3 +84,15 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!114 &5120778147521000280
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1765210580064862808}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ff7aa3ba2ede34b42aa0918d0b12d9ae, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/adventure-crew-game/Assets/Scenes/Tsingtao/Battlefield-Non-Test.unity
+++ b/adventure-crew-game/Assets/Scenes/Tsingtao/Battlefield-Non-Test.unity
@@ -344,7 +344,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!114 &87832487
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2211,7 +2211,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!114 &1218857429
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/adventure-crew-game/Assets/Scripts/Characters/AdventurerList.cs
+++ b/adventure-crew-game/Assets/Scripts/Characters/AdventurerList.cs
@@ -14,7 +14,7 @@ public static class AdventurerList
         int hp = rnd.Next(75, 100) * (rankInt + 1);
         int maxHP = hp;
         int damage = rnd.Next(8, 15) * (rankInt + 1);
-        int agility = rnd.Next(1, 4) * (rankInt + 1);
+        int agility = rnd.Next(1, 4);
         float range = UnityEngine.Random.Range(1, 10);
         Stats stats = new Stats(hp, maxHP, damage, agility, range);
         Adventurer adventurer = new Adventurer(stats);

--- a/adventure-crew-game/Assets/Scripts/Combat/Powers/PowerBulletTime.cs
+++ b/adventure-crew-game/Assets/Scripts/Combat/Powers/PowerBulletTime.cs
@@ -1,0 +1,15 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PowerBulletTime : MonoBehaviour
+{
+    private void OnEnable()
+    {
+        Time.timeScale = 0.2f;
+    }
+    private void OnDisable()
+    {
+        Time.timeScale = 1.0f;
+    }
+}

--- a/adventure-crew-game/Assets/Scripts/Combat/Powers/PowerBulletTime.cs.meta
+++ b/adventure-crew-game/Assets/Scripts/Combat/Powers/PowerBulletTime.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ff7aa3ba2ede34b42aa0918d0b12d9ae
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/adventure-crew-game/Assets/Scripts/Combat/Powers/PowerCursor.cs
+++ b/adventure-crew-game/Assets/Scripts/Combat/Powers/PowerCursor.cs
@@ -85,10 +85,16 @@ public class PowerCursor : MonoBehaviour
     // Mouse controls adapted from Between Root and Bough and originally implemented by Jared Goronkin
     private void OnLook(InputValue value)
     {
-        float adjustedXClamp = xClamp - powerCylinder.transform.localScale.x * 0.5f;
-        float adjustedZClamp = zClamp - powerCylinder.transform.localScale.z * 0.5f;
-        Vector2 input = Vector2.Scale(value.Get<Vector2>(), mouseSensitivity);
-        center = new Vector3(Mathf.Clamp(center.x + input.x, -adjustedXClamp, adjustedXClamp), 1, Mathf.Clamp(center.z + input.y, -adjustedZClamp, adjustedZClamp));
+        //float adjustedXClamp = xClamp - powerCylinder.transform.localScale.x * 0.5f;
+        //float adjustedZClamp = zClamp - powerCylinder.transform.localScale.z * 0.5f;
+        //Vector2 input = Vector2.Scale(value.Get<Vector2>(), mouseSensitivity);
+        //center = new Vector3(Mathf.Clamp(center.x + input.x, -adjustedXClamp, adjustedXClamp), 1, Mathf.Clamp(center.z + input.y, -adjustedZClamp, adjustedZClamp));
+        Ray ray = Camera.main.ScreenPointToRay(Input.mousePosition);
+        int layer_mask = LayerMask.GetMask("Formation");
+        if (Physics.Raycast(ray, out RaycastHit hit, Mathf.Infinity, layer_mask))
+        {
+            center = hit.point;
+        }
     }
 
     private void OnExecuteAction(InputValue value)


### PR DESCRIPTION
…weak numbers

<!---
Pull request template for 603 Game 3. Feel free to remove comments as you fill out information.
Original template by Rob Reddick
--->
## Summarize what is being added
<!--- Can use bullet lists here to cover new additions, but give a bit more detail than what is given in commit messages --->
Now the player places power with the mouse's psition
when activating a power, the battle time slows
lowered the agility when generating ad adventurer
## Please describe how to test
<!---Give the important steps needed for testing your main changes--->
To to combat-non-test scene, just generate a few, place some, start battle. Try with the powers
## Relevant Screenshots
<!---Paste in some screenshots to help reduce need of excess testing. If screenshots are not relevant here, then remove this section--->

## Issue worked on
<!---Paste in a link to the issue this PR addresses--->

## What Week of the 603 cycle is this due in?
<!---Only need to indicate here which week/deliverable the PR is for--->
