### PR TITLE
Coins text repositioned

### DIFF
--- a/adventure-crew-game/Assets/Prefabs/UI/IAP Holder.prefab
+++ b/adventure-crew-game/Assets/Prefabs/UI/IAP Holder.prefab
@@ -4454,15 +4454,15 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
+  m_Sprite: {fileID: 21300000, guid: 92be4a6c8c8b25747bc9fb5be2a5cd5f, type: 3}
+  m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4

--- a/adventure-crew-game/Assets/Scenes/MapScene.unity
+++ b/adventure-crew-game/Assets/Scenes/MapScene.unity
@@ -2484,37 +2484,6 @@ PrefabInstance:
       propertyPath: m_text
       value: 1000 Gold
       objectReference: {fileID: 0}
-    - target: {fileID: 8078824901640292558, guid: 7b8358ab526029f439229f96fb5c5c15,
-        type: 3}
-      propertyPath: m_Type
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8078824901640292558, guid: 7b8358ab526029f439229f96fb5c5c15,
-        type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 92be4a6c8c8b25747bc9fb5be2a5cd5f,
-        type: 3}
-    - target: {fileID: 8078824901640292558, guid: 7b8358ab526029f439229f96fb5c5c15,
-        type: 3}
-      propertyPath: m_Color.a
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8078824901640292558, guid: 7b8358ab526029f439229f96fb5c5c15,
-        type: 3}
-      propertyPath: m_Color.b
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8078824901640292558, guid: 7b8358ab526029f439229f96fb5c5c15,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8078824901640292558, guid: 7b8358ab526029f439229f96fb5c5c15,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 8460849158599410490, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchorMax.y

--- a/adventure-crew-game/Assets/Scenes/MapScene.unity
+++ b/adventure-crew-game/Assets/Scenes/MapScene.unity
@@ -1982,12 +1982,12 @@ PrefabInstance:
     - target: {fileID: 2029436965225251905, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2029436965225251905, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2029436965225251905, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
@@ -1997,17 +1997,17 @@ PrefabInstance:
     - target: {fileID: 2029436965225251905, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 543
       objectReference: {fileID: 0}
     - target: {fileID: 2029436965225251905, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 1125
       objectReference: {fileID: 0}
     - target: {fileID: 2029436965225251905, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -281.5
       objectReference: {fileID: 0}
     - target: {fileID: 2060941101119395919, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
@@ -2032,12 +2032,12 @@ PrefabInstance:
     - target: {fileID: 2783883204058635140, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2783883204058635140, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2783883204058635140, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
@@ -2047,17 +2047,17 @@ PrefabInstance:
     - target: {fileID: 2783883204058635140, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 543
       objectReference: {fileID: 0}
     - target: {fileID: 2783883204058635140, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 865
       objectReference: {fileID: 0}
     - target: {fileID: 2783883204058635140, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -281.5
       objectReference: {fileID: 0}
     - target: {fileID: 2822818547963157950, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
@@ -2097,12 +2097,12 @@ PrefabInstance:
     - target: {fileID: 4440500750868513866, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4440500750868513866, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4477013088702973330, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
@@ -2112,7 +2112,7 @@ PrefabInstance:
     - target: {fileID: 4477013088702973330, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4649212931644093724, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
@@ -2152,12 +2152,12 @@ PrefabInstance:
     - target: {fileID: 5624577025433913000, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5624577025433913000, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5624577025433913000, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
@@ -2167,17 +2167,17 @@ PrefabInstance:
     - target: {fileID: 5624577025433913000, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 543
       objectReference: {fileID: 0}
     - target: {fileID: 5624577025433913000, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 605
       objectReference: {fileID: 0}
     - target: {fileID: 5624577025433913000, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -281.5
       objectReference: {fileID: 0}
     - target: {fileID: 5718128045008643572, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
@@ -2187,12 +2187,12 @@ PrefabInstance:
     - target: {fileID: 5929471840890219692, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5929471840890219692, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5929471840890219692, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
@@ -2202,17 +2202,17 @@ PrefabInstance:
     - target: {fileID: 5929471840890219692, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 543
       objectReference: {fileID: 0}
     - target: {fileID: 5929471840890219692, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 110
       objectReference: {fileID: 0}
     - target: {fileID: 5929471840890219692, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -553
       objectReference: {fileID: 0}
     - target: {fileID: 5973040900898865678, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
@@ -2412,27 +2412,27 @@ PrefabInstance:
     - target: {fileID: 7147528325085402686, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7147528325085402686, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7147528325085402686, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: -17
       objectReference: {fileID: 0}
     - target: {fileID: 7154543176771750399, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7154543176771750399, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7154543176771750399, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
@@ -2442,17 +2442,17 @@ PrefabInstance:
     - target: {fileID: 7154543176771750399, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 543
       objectReference: {fileID: 0}
     - target: {fileID: 7154543176771750399, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 1385
       objectReference: {fileID: 0}
     - target: {fileID: 7154543176771750399, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -281.5
       objectReference: {fileID: 0}
     - target: {fileID: 7232471351943919158, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
@@ -2487,12 +2487,12 @@ PrefabInstance:
     - target: {fileID: 8460849158599410490, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8460849158599410490, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8460849158599410490, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
@@ -2502,22 +2502,22 @@ PrefabInstance:
     - target: {fileID: 8460849158599410490, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 543
       objectReference: {fileID: 0}
     - target: {fileID: 8460849158599410490, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 345
       objectReference: {fileID: 0}
     - target: {fileID: 8460849158599410490, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -281.5
       objectReference: {fileID: 0}
     - target: {fileID: 8840441382274116990, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 1520
       objectReference: {fileID: 0}
     - target: {fileID: 8840441382274116990, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}

--- a/adventure-crew-game/Assets/Scenes/MapScene.unity
+++ b/adventure-crew-game/Assets/Scenes/MapScene.unity
@@ -262,7 +262,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &27188009
 RectTransform:
   m_ObjectHideFlags: 0
@@ -1982,12 +1982,12 @@ PrefabInstance:
     - target: {fileID: 2029436965225251905, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2029436965225251905, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2029436965225251905, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
@@ -1997,17 +1997,17 @@ PrefabInstance:
     - target: {fileID: 2029436965225251905, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 543
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2029436965225251905, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 1125
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2029436965225251905, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -281.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2060941101119395919, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
@@ -2032,12 +2032,12 @@ PrefabInstance:
     - target: {fileID: 2783883204058635140, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2783883204058635140, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2783883204058635140, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
@@ -2047,17 +2047,17 @@ PrefabInstance:
     - target: {fileID: 2783883204058635140, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 543
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2783883204058635140, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 865
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2783883204058635140, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -281.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2822818547963157950, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
@@ -2097,12 +2097,12 @@ PrefabInstance:
     - target: {fileID: 4440500750868513866, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4440500750868513866, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4477013088702973330, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
@@ -2112,7 +2112,7 @@ PrefabInstance:
     - target: {fileID: 4477013088702973330, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4649212931644093724, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
@@ -2152,12 +2152,12 @@ PrefabInstance:
     - target: {fileID: 5624577025433913000, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5624577025433913000, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5624577025433913000, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
@@ -2167,17 +2167,17 @@ PrefabInstance:
     - target: {fileID: 5624577025433913000, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 543
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5624577025433913000, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 605
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5624577025433913000, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -281.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5718128045008643572, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
@@ -2187,12 +2187,12 @@ PrefabInstance:
     - target: {fileID: 5929471840890219692, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5929471840890219692, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5929471840890219692, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
@@ -2202,17 +2202,17 @@ PrefabInstance:
     - target: {fileID: 5929471840890219692, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 543
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5929471840890219692, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 110
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5929471840890219692, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -553
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5973040900898865678, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
@@ -2412,27 +2412,27 @@ PrefabInstance:
     - target: {fileID: 7147528325085402686, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7147528325085402686, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7147528325085402686, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: -17
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7154543176771750399, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7154543176771750399, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7154543176771750399, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
@@ -2442,17 +2442,17 @@ PrefabInstance:
     - target: {fileID: 7154543176771750399, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 543
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7154543176771750399, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 1385
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7154543176771750399, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -281.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7232471351943919158, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
@@ -2487,12 +2487,12 @@ PrefabInstance:
     - target: {fileID: 8460849158599410490, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8460849158599410490, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8460849158599410490, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
@@ -2502,22 +2502,22 @@ PrefabInstance:
     - target: {fileID: 8460849158599410490, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 543
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8460849158599410490, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 345
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8460849158599410490, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -281.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8840441382274116990, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 1520
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8840441382274116990, guid: 7b8358ab526029f439229f96fb5c5c15,
         type: 3}
@@ -3453,11 +3453,11 @@ RectTransform:
   m_Father: {fileID: 8671286}
   m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -813, y: 489}
-  m_SizeDelta: {x: 200, y: 50}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: -30}
+  m_SizeDelta: {x: 347.1, y: 100}
+  m_Pivot: {x: 0.5, y: 1}
 --- !u!114 &1151744364
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3480,8 +3480,9 @@ MonoBehaviour:
       m_Calls: []
   m_text: New Text
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: e383dc57daf997d4abcd000a550adbd0, type: 2}
+  m_sharedMaterial: {fileID: 877897986941153224, guid: e383dc57daf997d4abcd000a550adbd0,
+    type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -3505,15 +3506,15 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 36
+  m_fontSize: 69.3
   m_fontSizeBase: 36
   m_fontWeight: 400
-  m_enableAutoSizing: 0
+  m_enableAutoSizing: 1
   m_fontSizeMin: 18
   m_fontSizeMax: 72
   m_fontStyle: 0
-  m_HorizontalAlignment: 1
-  m_VerticalAlignment: 256
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
   m_wordSpacing: 0

--- a/adventure-crew-game/Assets/Scripts/UI/DisplayCoin.cs
+++ b/adventure-crew-game/Assets/Scripts/UI/DisplayCoin.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
+
 public class DisplayCoin : MonoBehaviour
 {
     public TMP_Text coinText;
@@ -10,8 +11,9 @@ public class DisplayCoin : MonoBehaviour
     private void Start()
     {
         coinText = GetComponent<TMP_Text>();
-        InvokeRepeating(nameof(updateCoinText), 1.0f, 1.0f);
+        InvokeRepeating(nameof(updateCoinText), 0.0f, 1.0f);
     }
+
     private void updateCoinText()
     {
         coinText.text = "Gold: " + CurrencySystem.Coins.ToString();


### PR DESCRIPTION
<!---
Pull request template for 603 Game 3. Feel free to remove comments as you fill out information.
Original template by Rob Reddick
--->
## Summarize what is being added
<!--- Can use bullet lists here to cover new additions, but give a bit more detail than what is given in commit messages --->
Repositions coins text, as it was overlapping with close button from the UI.
## Please describe how to test
<!---Give the important steps needed for testing your main changes--->

1. Play the game from the beginning.
2. The coin text should now appear on the top-middle of the screen.

## Relevant Screenshots
<!---Paste in some screenshots to help reduce need of excess testing. If screenshots are not relevant here, then remove this section--->
![image](https://github.com/amonjerro/adventure-crew/assets/145331737/04586a21-39a6-48f4-9add-5d074dbe24f6)

## Issue worked on
<!---Paste in a link to the issue this PR addresses--->
#76 
## What Week of the 603 cycle is this due in?
<!---Only need to indicate here which week/deliverable the PR is for--->
Week 3 / Final